### PR TITLE
Update fedora prerequisites

### DIFF
--- a/cargo-embed/CHANGELOG.md
+++ b/cargo-embed/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
 - Update description of Fedora prequisites in README.md
 
 ## [0.17.0]

--- a/cargo-embed/CHANGELOG.md
+++ b/cargo-embed/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Update Fedora description of prequisites in README.md
 
 ## [0.17.0]
 

--- a/cargo-embed/CHANGELOG.md
+++ b/cargo-embed/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Update Fedora description of prequisites in README.md
+- Update description of Fedora prequisites in README.md
 
 ## [0.17.0]
 

--- a/cargo-embed/README.md
+++ b/cargo-embed/README.md
@@ -97,7 +97,7 @@ On Ubuntu or Debian, the following packages need to be installed:
 For Fedora or CentOS
 
 ```
-> dnf install systemd-devel
+> dnf install systemd-devel libusbx-devel
 ```
 
 You may also need to remove old versions of libusb:


### PR DESCRIPTION
The cargo-embed install was complaining about being "Unable to find libusb-1.0" until I also installed libusbx-devel, so am suggesting that the readme gets updated to reflect this.